### PR TITLE
Add change to fetchKuzzle

### DIFF
--- a/src/use-kuzzle.js
+++ b/src/use-kuzzle.js
@@ -232,8 +232,8 @@ export function fetchKuzzle(options) {
   }
 
   const kuzzle = useKuzzle(options);
-  const isFetching = value(false);
-  const isChanging = value(false);
+  const isReading = value(false);
+  const isWriting = value(false);
   const rawData = value(null);
   const error = value(null);
 
@@ -248,8 +248,8 @@ export function fetchKuzzle(options) {
 
   const setError = err => {
     error.value = err;
-    isFetching.value = false;
-    isChanging.value = false;
+    isReading.value = false;
+    isWriting.value = false;
     if (typeof options.error === 'function') {
       options.error(err);
     } else {
@@ -270,14 +270,14 @@ export function fetchKuzzle(options) {
       if (!id) {
         return;
       }
-      isFetching.value = true;
+      isReading.value = true;
       await kuzzle.provider.connectAll();
       try {
         const { _kuzzle_response, ...dataValue } = await kuzzle.get(
           id,
           options,
         );
-        isFetching.value = false;
+        isReading.value = false;
         if (options.update) {
           rawData.value = options.update(dataValue, _kuzzle_response);
         } else {
@@ -296,7 +296,7 @@ export function fetchKuzzle(options) {
   );
 
   const change = async newDoc => {
-    isChanging.value = true;
+    isWriting.value = true;
     if (!changePromise) {
       changePromise = Promise.resolve(null);
     }
@@ -335,7 +335,7 @@ export function fetchKuzzle(options) {
         }
         // No changes to be applied
         if (!changeDoc || Object.keys(changeDoc).length === 0) {
-          isChanging.value = false;
+          isWriting.value = false;
           return savedDoc;
         }
         // Attempt change
@@ -391,7 +391,7 @@ export function fetchKuzzle(options) {
           if (changePromise === currentChangeRun) {
             rawData.value = returnDoc;
           }
-          isChanging.value = false;
+          isWriting.value = false;
           return returnDoc;
         } catch (err) {
           setError(err);
@@ -403,15 +403,15 @@ export function fetchKuzzle(options) {
   };
 
   const isLoading = computed(() => {
-    return isFetching.value || isChanging.value;
+    return isReading.value || isWriting.value;
   });
 
   const data = computed(() => rawData.value, change);
 
   return {
     kuzzle,
-    isFetching,
-    isChanging,
+    isReading,
+    isWriting,
     isLoading,
     data,
     error,

--- a/src/use-kuzzle.js
+++ b/src/use-kuzzle.js
@@ -314,6 +314,7 @@ export function fetchKuzzle(options) {
           'change',
         );
         const changeContext = {
+          kuzzle,
           index,
           collection,
           id: documentId.value,
@@ -356,7 +357,7 @@ export function fetchKuzzle(options) {
             updateResp = await client.document.createOrReplace(
               index,
               collection,
-              ocumentId.value,
+              documentId.value,
               changeDoc,
               {
                 refresh: 'wait_for',
@@ -366,7 +367,7 @@ export function fetchKuzzle(options) {
             updateResp = await client.document.update(
               index,
               collection,
-              ocumentId.value,
+              documentId.value,
               changeDoc,
               {
                 refresh: 'wait_for',

--- a/src/use-kuzzle.js
+++ b/src/use-kuzzle.js
@@ -483,7 +483,7 @@ export function searchKuzzle(options) {
                 from: search.from,
                 size: search.size,
               }
-            : {},
+            : options,
         );
         isLoading.value = false;
         setData(resp, resp._kuzzle_response);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 export function getRootChanges(reference, obj) {
   const res = {};
   for (const key in obj) {
-    if (!eq(obj[key], reference[key], true)) {
+    if (!eq(obj[key], reference[key])) {
       res[key] = obj[key];
     }
   }

--- a/types/useKuzzle.d.ts
+++ b/types/useKuzzle.d.ts
@@ -80,6 +80,7 @@ export function fetchKuzzle<R = any>(
   isLoading: Wrapper<boolean>;
   data: Wrapper<R>;
   error: Wrapper<Error>;
+  change: (newDoc: R) => Promise<R>;
 };
 
 export function searchKuzzle<R = any>(

--- a/types/useKuzzle.d.ts
+++ b/types/useKuzzle.d.ts
@@ -77,6 +77,8 @@ export function fetchKuzzle<R = any>(
   options: VueKuzzleDocumentOptions<any, R>,
 ): {
   kuzzle: UseKuzzle;
+  isFetching: Wrapper<boolean>;
+  isChanging: Wrapper<boolean>;
   isLoading: Wrapper<boolean>;
   data: Wrapper<R>;
   error: Wrapper<Error>;

--- a/types/useKuzzle.d.ts
+++ b/types/useKuzzle.d.ts
@@ -77,8 +77,8 @@ export function fetchKuzzle<R = any>(
   options: VueKuzzleDocumentOptions<any, R>,
 ): {
   kuzzle: UseKuzzle;
-  isFetching: Wrapper<boolean>;
-  isChanging: Wrapper<boolean>;
+  isReading: Wrapper<boolean>;
+  isWriting: Wrapper<boolean>;
   isLoading: Wrapper<boolean>;
   data: Wrapper<R>;
   error: Wrapper<Error>;


### PR DESCRIPTION
This PRs adds the `change` method to `fetchKuzzle` so that a user can send changes to the server.

editing the `data` value will also work by calling `change` 