### PR TITLE
Provider hooks

### DIFF
--- a/src/kuzzle-provider.js
+++ b/src/kuzzle-provider.js
@@ -11,6 +11,7 @@ export class KuzzleProvider {
     this.watchLoading = options.watchLoading;
     this.errorHandler = options.errorHandler;
     this.beforeChange = options.beforeChange;
+    this.afterFetch = options.afterFetch;
 
     this.connectAll();
   }

--- a/src/kuzzle-provider.js
+++ b/src/kuzzle-provider.js
@@ -10,7 +10,7 @@ export class KuzzleProvider {
     this.defaultCollection = options.defaultCollection;
     this.watchLoading = options.watchLoading;
     this.errorHandler = options.errorHandler;
-    this.changeFilter = options.changeFilter;
+    this.beforeChange = options.beforeChange;
 
     this.connectAll();
   }

--- a/src/smart-document.js
+++ b/src/smart-document.js
@@ -197,14 +197,14 @@ export default class SmartQuery extends SmartKuzzle {
           savedDocument: savedDoc,
           changedDocument: newDoc,
         };
-        const changeFilter =
-          this.options.changeFilter ||
-          this.vm.$kuzzle.changeFilter ||
-          this.vm.$kuzzle.provider.changeFilter;
-        if (typeof changeFilter === 'function') {
+        const beforeChange =
+          this.options.beforeChange ||
+          this.vm.$kuzzle.beforeChange ||
+          this.vm.$kuzzle.provider.beforeChange;
+        if (typeof beforeChange === 'function') {
           try {
             changeDoc = await Promise.resolve(
-              changeFilter.call(this.vm, changeDoc, changeContext),
+              beforeChange.call(this.vm, changeDoc, changeContext),
             );
           } catch (error) {
             this.catchError(error);

--- a/src/smart-document.js
+++ b/src/smart-document.js
@@ -92,6 +92,14 @@ export default class SmartQuery extends SmartKuzzle {
     if (!doc) {
       return;
     }
+    if (typeof this.vm.$kuzzle.provider.afterFetch === 'function') {
+      doc = this.vm.$kuzzle.provider.afterFetch.call(
+        this.vm,
+        doc,
+        response,
+        operation,
+      );
+    }
     if (typeof this.options.update === 'function') {
       const respDoc = await Promise.resolve(
         this.options.update.call(this.vm, doc, response, operation),

--- a/src/smart-search.js
+++ b/src/smart-search.js
@@ -54,6 +54,14 @@ export default class SmartSearch extends SmartKuzzle {
   }
 
   nextResult(data, response) {
+    if (typeof this.vm.$kuzzle.provider.afterFetch === 'function') {
+      doc = this.vm.$kuzzle.provider.afterFetch.call(
+        this.vm,
+        data,
+        response,
+        'search',
+      );
+    }
     if (typeof this.options.update === 'function') {
       this.setData(this.options.update.call(this.vm, data, response));
     } else {

--- a/src/use-kuzzle.js
+++ b/src/use-kuzzle.js
@@ -324,12 +324,12 @@ export function fetchKuzzle(options) {
           changedDocument: newDoc,
           // key missing
         };
-        const changeFilter =
-          options.changeFilter || kuzzle.provider.changeFilter;
-        if (typeof changeFilter === 'function') {
+        const beforeChange =
+          options.beforeChange || kuzzle.provider.beforeChange;
+        if (typeof beforeChange === 'function') {
           try {
             changeDoc = await Promise.resolve(
-              changeFilter(changeDoc, changeContext),
+              beforeChange(changeDoc, changeContext),
             );
           } catch (err) {
             setError(err);

--- a/src/use-kuzzle.js
+++ b/src/use-kuzzle.js
@@ -77,6 +77,9 @@ export function useKuzzle(config) {
     return { index, collection };
   };
 
+  const afterFetch =
+    typeof provider.afterFetch === 'function' ? provider.afterFetch : x => x;
+
   const query = (body, options) => {
     const { index, collection } = getIndexAndCollection(options);
     try {
@@ -102,7 +105,7 @@ export function useKuzzle(config) {
       id,
     );
     return {
-      ...response._source,
+      ...afterFetch.call(null, response._source, response, 'get'),
       _kuzzle_response: response,
     };
   };
@@ -125,9 +128,10 @@ export function useKuzzle(config) {
         size: (options && options.size) || 10,
       },
     );
-    const hits = (_kuzzle_response.hits || [])
+    let hits = (_kuzzle_response.hits || [])
       .slice()
       .map(({ _source }) => _source);
+    hits = afterFetch.call(null, hits, _kuzzle_response, 'search');
     hits._kuzzle_response = _kuzzle_response;
     return hits;
   };
@@ -164,7 +168,12 @@ export function useKuzzle(config) {
       },
     );
     return {
-      ..._kuzzle_response._source,
+      ...afterFetch.call(
+        null,
+        _kuzzle_response._source,
+        _kuzzle_response,
+        _kuzzle_response.created ? 'create' : _kuzzle_response.result,
+      ),
       _kuzzle_response,
     };
   };
@@ -196,7 +205,12 @@ export function useKuzzle(config) {
       },
     );
     return {
-      ..._kuzzle_response._source,
+      ...afterFetch.call(
+        null,
+        _kuzzle_response._source,
+        _kuzzle_response,
+        _kuzzle_response.response,
+      ),
       _kuzzle_response,
     };
   };
@@ -329,7 +343,7 @@ export function fetchKuzzle(options) {
         if (typeof beforeChange === 'function') {
           try {
             changeDoc = await Promise.resolve(
-              beforeChange(changeDoc, changeContext),
+              beforeChange.call(null, changeDoc, changeContext),
             );
           } catch (err) {
             setError(err);

--- a/types/kuzzle-provider.d.ts
+++ b/types/kuzzle-provider.d.ts
@@ -13,16 +13,20 @@ export type VueKuzzleComponent<V extends Vue = Vue> =
   | typeof Vue
   | AsyncComponent;
 
-export class KuzzleProvider {
+export class KuzzleProvider<V = any> {
   constructor(options: {
     defaultClient: Kuzzle;
     defaultIndex?: string;
     defaultCollection?: string;
-    defaultOptions?: VueKuzzleOptions<any>;
+    defaultOptions?: VueKuzzleOptions<V>;
     clients?: { [key: string]: Kuzzle };
-    watchLoading?: WatchLoading<any>;
-    errorHandler?: ErrorHandler<any>;
-    changeFilter?: ChangeFilter<any>;
+    watchLoading?: WatchLoading<V>;
+    errorHandler?: ErrorHandler<V>;
+    /**
+     * A filter function to be applied to all documents before they are
+     * changed. This method should return the document to be sent to the server.
+     */
+    beforeChange?: ChangeFilter<V>;
   });
   clients: { [key: string]: Kuzzle };
   defaultClient: Kuzzle;

--- a/types/kuzzle-provider.d.ts
+++ b/types/kuzzle-provider.d.ts
@@ -1,12 +1,13 @@
 import Vue, { AsyncComponent } from 'vue';
 import { Kuzzle } from 'kuzzle-sdk';
-import { VueKuzzleComponentOption } from './options';
+import { VueKuzzleComponentOption, FetchFilter } from './options';
 import {
   WatchLoading,
   ErrorHandler,
   VueKuzzleOptions,
   ChangeFilter,
 } from './options';
+import { UseKuzzle } from './useKuzzle';
 
 export type VueKuzzleComponent<V extends Vue = Vue> =
   | VueKuzzleComponentOption<V>
@@ -27,6 +28,11 @@ export class KuzzleProvider<V = any> {
      * changed. This method should return the document to be sent to the server.
      */
     beforeChange?: ChangeFilter<V>;
+    /**
+     * A filter function to be applied to all documents or searches that are
+     * fetched from the server.
+     */
+    afterFetch?: FetchFilter<V>;
   });
   clients: { [key: string]: Kuzzle };
   defaultClient: Kuzzle;

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -56,7 +56,7 @@ export interface VueKuzzleDocumentOptions<V, R>
     resp: KuzzleDocumentGetResponse<R> | KuzzleDocumentUpdateResponse,
     op: 'get' | 'subscription' | 'update' | 'replace',
   ) => any;
-  changeFilter?: ChangeFilter<V>;
+  beforeChange?: ChangeFilter<V>;
 }
 
 export interface VueKuzzleSearchOptions<V, R>

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -3,6 +3,7 @@ import {
   KuzzleDocumentSearchResponse,
   KuzzleDocumentUpdateResponse,
 } from 'kuzzle-sdk';
+import { UseKuzzle } from './useKuzzle';
 
 type VueKuzzleThisType<V> = V & { [key: string]: any };
 
@@ -11,7 +12,9 @@ export type WatchLoading<V> = (
   isLoading: boolean,
   countModifier: number,
 ) => void;
+
 export type ErrorHandler<V> = (this: VueKuzzleThisType<V>, error: any) => void;
+
 export type VueKuzzleSearchConfig = {
   query?: object;
   aggregations?: object;
@@ -19,18 +22,35 @@ export type VueKuzzleSearchConfig = {
   from?: number;
   size?: number;
 };
-export type ChangeContext = {
+
+export type FilterContext<Extra = never> = Extra & {
   index: string;
   collection: string;
   id: string;
-  documentKey: string;
-  savedDocument: any;
-  updatedDocument: any;
 };
+
 export type ChangeFilter<V> = (
   this: VueKuzzleThisType<V>,
   changeDocument: any,
-  changeContext: ChangeContext,
+  changeContext: FilterContext<
+    ([V] extends [never] ? { kuzzle: UseKuzzle } : { documentKey: string }) & {
+      savedDocument: any;
+      updatedDocument: any;
+    }
+  >,
+) => any;
+
+type UpdateFilterResponse<R> =
+  | KuzzleDocumentResponse<R>
+  | KuzzleDocumentSearchResponse<R>;
+
+type UpdateFilterOperation = KuzzleDocumentOperation | 'search';
+
+export type FetchFilter<V, R = any> = (
+  this: VueKuzzleThisType<V>,
+  data: R,
+  resp: UpdateFilterResponse<R>,
+  operation: UpdateFilterOperation,
 ) => any;
 
 interface ExtendableVueKuzzleQueryOptions<V, R> {
@@ -46,16 +66,30 @@ interface ExtendableVueKuzzleQueryOptions<V, R> {
   deep?: boolean;
 }
 
+type KuzzleDocumentResponse<R> =
+  | KuzzleDocumentGetResponse<R>
+  | KuzzleDocumentUpdateResponse;
+
+type KuzzleDocumentOperation = 'get' | 'subscription' | 'create' | 'update' | 'replace';
+
 export interface VueKuzzleDocumentOptions<V, R>
   extends ExtendableVueKuzzleQueryOptions<V, R> {
   subscribe?: boolean;
   document: ((this: VueKuzzleThisType<V>) => string) | string;
+  /**
+   * Apply a transformation to get or update responses.
+   */
   update?: (
     this: VueKuzzleThisType<V>,
     data: R,
-    resp: KuzzleDocumentGetResponse<R> | KuzzleDocumentUpdateResponse,
-    op: 'get' | 'subscription' | 'update' | 'replace',
+    resp: KuzzleDocumentResponse<R>,
+    op: KuzzleDocumentOperation,
   ) => any;
+  /**
+   * Apply a transformation to documents before they are sent to
+   * the server. The returned document will be sent to the server.
+   * Returning null or an empty object will cancel the change.
+   */
   beforeChange?: ChangeFilter<V>;
 }
 

--- a/types/vue-kuzzle.d.ts
+++ b/types/vue-kuzzle.d.ts
@@ -15,7 +15,7 @@ import {
   KuzzleDocumentCreateReplaceResponse,
 } from 'kuzzle-sdk';
 
-export class VueKuzzle extends KuzzleProvider implements PluginObject<{}> {
+export class VueKuzzle<V = Vue> extends KuzzleProvider<V> implements PluginObject<{}> {
   [key: string]: any;
   install: PluginFunction<{}>;
 


### PR DESCRIPTION
Adds a new hook to the provider to map all fetch results. Use the new `afterFetch` to modify fetch results before they are sent to the `update` functions.